### PR TITLE
disable software CRC

### DIFF
--- a/drivers/mmc/core/core.c
+++ b/drivers/mmc/core/core.c
@@ -75,7 +75,7 @@ static const unsigned freqs[] = { 400000, 300000, 200000, 100000 };
  * performance cost, and for other reasons may not always be desired.
  * So we allow it it to be disabled.
  */
-bool use_spi_crc = 1;
+bool use_spi_crc = 0;
 module_param(use_spi_crc, bool, 0);
 
 /*


### PR DESCRIPTION
/*
 * Enabling software CRCs on the data blocks can be a significant (30%)
 * performance cost, and for other reasons may not always be desired.
 * So we allow it it to be disabled.
 */

WIKI: https://en.wikipedia.org/wiki/Cyclic_redundancy_check

Note that im not the one who found this. I have seen it at other kernel. What do you think about CRC?